### PR TITLE
redesign the observer

### DIFF
--- a/simulator/pom.xml
+++ b/simulator/pom.xml
@@ -22,7 +22,7 @@
   	<dependency>
     	<groupId>org.bouncycastle</groupId>
     	<artifactId>bcprov-jdk15on</artifactId>
-    	<version>1.66</version>
+    	<version>1.70</version>
 	</dependency>
 	<dependency>
     	<groupId>com.github.seancfoley</groupId>

--- a/simulator/src/main/java/peersim/kademlia/KademliaObserver.java
+++ b/simulator/src/main/java/peersim/kademlia/KademliaObserver.java
@@ -131,6 +131,7 @@ public class KademliaObserver implements Control {
   }
 
   public static void reportMsg(Message m, boolean sent) {
+    assert (messages.keySet().contains(String.valueOf(m.id)));
     messages.put(String.valueOf(m.id), m.toMap(sent));
   }
 }

--- a/simulator/src/main/java/peersim/kademlia/KademliaProtocol.java
+++ b/simulator/src/main/java/peersim/kademlia/KademliaProtocol.java
@@ -191,7 +191,7 @@ public class KademliaProtocol implements Cloneable, EDProtocol {
           Message request = new Message(Message.MSG_FIND);
           request.operationId = m.operationId;
           request.src = this.getNode();
-          request.dest = m.dest;
+          request.dst = m.dst;
           request.body = fop.destNode;
           // increment hop count
           fop.nrHops++;
@@ -240,7 +240,7 @@ public class KademliaProtocol implements Cloneable, EDProtocol {
     // create a response message containing the neighbours (with the same id of the request)
     Message response = new Message(Message.MSG_RESPONSE, neighbours);
     response.operationId = m.operationId;
-    response.dest = m.dest;
+    response.dst = m.dst;
     response.src = this.getNode();
     response.ackId = m.id; // set ACK number
 
@@ -282,7 +282,7 @@ public class KademliaProtocol implements Cloneable, EDProtocol {
     for (int i = 0; i < KademliaCommonConfig.ALPHA; i++) {
       BigInteger nextNode = fop.getNeighbour();
       if (nextNode != null) {
-        m.dest =
+        m.dst =
             nodeIdtoNode(nextNode).getKademliaProtocol().getNode(); // new KademliaNode(nextNode);
         sendMessage(m.copy(), nextNode, myPid);
         fop.nrHops++;
@@ -303,7 +303,7 @@ public class KademliaProtocol implements Cloneable, EDProtocol {
     this.routingTable.addNeighbour(destId);
     // int destpid;
     assert m.src != null;
-    assert m.dest != null;
+    assert m.dst != null;
 
     Node src = nodeIdtoNode(this.getNode().getId());
     Node dest = nodeIdtoNode(destId);

--- a/simulator/src/main/java/peersim/kademlia/Message.java
+++ b/simulator/src/main/java/peersim/kademlia/Message.java
@@ -1,5 +1,8 @@
 package peersim.kademlia;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Message class provide all functionalities to magage the various messages, principally LOOKUP
  * messages (messages from application level sender destinated to another application level).<br>
@@ -78,7 +81,7 @@ public class Message extends SimpleEvent {
   public long operationId;
 
   /** Recipient node of the message */
-  public KademliaNode dest;
+  public KademliaNode dst;
 
   /** Source node of the message: has to be filled at application level */
   public KademliaNode src;
@@ -152,8 +155,8 @@ public class Message extends SimpleEvent {
 
   // ______________________________________________________________________________________________
   public String toString() {
-    String s = "[ID=" + id + "][DEST=" + dest + "]";
-    return s + "[Type=" + messageTypetoString() + "] BODY=(...)";
+    String s = "[ID=" + id + "][DEST=" + dst + "]";
+    return s + "[Type=" + typeToString() + "] BODY=(...)";
   }
 
   // ______________________________________________________________________________________________
@@ -161,7 +164,7 @@ public class Message extends SimpleEvent {
     Message dolly = new Message();
     dolly.type = this.type;
     dolly.src = this.src;
-    dolly.dest = this.dest;
+    dolly.dst = this.dst;
     dolly.operationId = this.operationId;
     dolly.body = this.body; // deep cloning?
 
@@ -169,7 +172,7 @@ public class Message extends SimpleEvent {
   }
 
   // ______________________________________________________________________________________________
-  public String messageTypetoString() {
+  public String typeToString() {
     switch (type) {
       case MSG_EMPTY:
         return "MSG_EMPTY";
@@ -200,5 +203,20 @@ public class Message extends SimpleEvent {
       default:
         return "UNKNOW:" + type;
     }
+  }
+
+  public Map<String, Object> toMap(boolean sent) {
+    Map<String, Object> result = new HashMap<String, Object>();
+    result.put("id", this.id);
+    result.put("type", this.typeToString());
+    result.put("src", this.src);
+    result.put("dst", this.dst);
+    if (sent) {
+      result.put("status", "sent");
+    } else {
+      result.put("status", "received");
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
It's just a proposal to redesign the KademliaObserver. All the stats we collect should be in the following format:
`HashMap<String id, Map<String feature, Object value>>`

As long as it's the case, we can print handle it with a single line of code. 

I also changed the code so the file is written out only once (rather than per line). It should speed up the simulations, but we have to be careful about the memory usage. 