### PR TITLE
samples with double id assignment by row and column reference

### DIFF
--- a/simulator/config/dasprotocoldouble.cfg
+++ b/simulator/config/dasprotocoldouble.cfg
@@ -5,7 +5,7 @@
 # ::::: GLOBAL ::::::
 
 # Network size
-SIZE 1000
+SIZE 2000
 
 # Random seed
 K 5
@@ -60,12 +60,10 @@ protocol.4dasprotocol peersim.kademlia.das.DASProtocol
 protocol.4dasprotocol.transport 2unreltr
 protocol.4dasprotocol.kademlia 3kademlia
 
-
 protocol.5evildasprotocol peersim.kademlia.das.EvilDASProtocol
 protocol.5evildasprotocol.transport 2unreltr
 protocol.5evildasprotocol.kademlia 3kademlia
 init.1uniqueNodeID.protocolEvildas 5evildasprotocol
-
 
 # ::::: INITIALIZERS :::::
 #Class that initializes nodes with kademlia protocol and generates uniform ids
@@ -73,6 +71,7 @@ init.1uniqueNodeID peersim.kademlia.das.CustomDistributionDas
 init.1uniqueNodeID.protocolkad 3kademlia
 init.1uniqueNodeID.protocoldas 4dasprotocol
 init.1uniqueNodeID.protocolEvildas 5evildasprotocol
+
 
 #Adds initial state to the routing tables
 init.2statebuilder peersim.kademlia.StateBuilder
@@ -82,13 +81,13 @@ init.2statebuilder.transport 2unreltr
 # ::::: CONTROLS :::::
 
 #TrafficGenerator class sends and initial 
-control.0traffic peersim.kademlia.das.TrafficGeneratorSample
+control.0traffic peersim.kademlia.das.TrafficGeneratorDoubleSample
 control.0traffic.kadprotocol 3kademlia
 control.0traffic.dasprotocol 4dasprotocol
 control.0traffic.step TRAFFIC_STEP
 control.0traffic.mapping_fn 2
-control.0traffic.sample_copy_per_node 3
-control.0traffic.block_dim_size 512
+control.0traffic.sample_copy_per_node 2
+control.0traffic.block_dim_size 100
 
 # turbulence
 #control.2turbolenceAdd peersim.kademlia.Turbulence

--- a/simulator/src/main/java/peersim/kademlia/das/Block.java
+++ b/simulator/src/main/java/peersim/kademlia/das/Block.java
@@ -34,33 +34,41 @@ public class Block implements Iterator<Sample>, Cloneable {
   /** number of samples in a block */
   private int numSamples;
 
-  private TreeSet<BigInteger> samples;
+  // private TreeSet<BigInteger> samples;
+  private TreeSet<BigInteger> samplesByRow;
+  private TreeSet<BigInteger> samplesByColumn;
 
+  // Constructor with block id
   public Block(long id) {
 
     SIZE = 512;
     this.numSamples = this.SIZE * this.SIZE;
     _init();
 
-    samples = new TreeSet<>();
+    samplesByRow = new TreeSet<>();
+    samplesByColumn = new TreeSet<>();
+
     this.blockId = id;
     blockSamples = new Sample[SIZE][SIZE];
     row = column = 0;
 
     for (int i = 0; i < blockSamples.length; i++) {
       for (int j = 0; j < blockSamples[0].length; j++) {
-        blockSamples[i][j] = new Sample(blockId, i, j, this);
-        samples.add(blockSamples[i][j].getId());
+        blockSamples[i][j] = new Sample(blockId, i + 1, j + 1, this);
+        samplesByRow.add(blockSamples[i][j].getIdByRow());
+        samplesByColumn.add(blockSamples[i][j].getIdByColumn());
       }
     }
   }
 
+  // Constructor specifying block id and matrix size
   public Block(int size, long id) {
 
     SIZE = size;
     this.numSamples = this.SIZE * this.SIZE;
     _init();
-    samples = new TreeSet<>();
+    samplesByRow = new TreeSet<>();
+    samplesByColumn = new TreeSet<>();
 
     this.blockId = id;
     blockSamples = new Sample[SIZE][SIZE];
@@ -68,20 +76,32 @@ public class Block implements Iterator<Sample>, Cloneable {
 
     for (int i = 0; i < blockSamples.length; i++) {
       for (int j = 0; j < blockSamples[0].length; j++) {
-        blockSamples[i][j] = new Sample(blockId, i, j, this);
-        samples.add(blockSamples[i][j].getId());
+        blockSamples[i][j] = new Sample(blockId, i + 1, j + 1, this);
+        samplesByRow.add(blockSamples[i][j].getIdByRow());
+        samplesByColumn.add(blockSamples[i][j].getIdByColumn());
       }
     }
   }
 
-  public Block(Sample[][] blockSamples, TreeSet<BigInteger> samples, int size, long id) {
+  // Constructor used when cloning
+  public Block(Sample[][] blockSamples, int size, long id) {
     SIZE = size;
     this.numSamples = this.SIZE * this.SIZE;
     _init();
-    this.samples = samples;
     this.blockSamples = blockSamples;
     row = column = 0;
     this.blockId = id;
+    // samples = new TreeSet<>();
+    samplesByRow = new TreeSet<>();
+    samplesByColumn = new TreeSet<>();
+
+    for (int i = 0; i < blockSamples.length; i++) {
+      for (int j = 0; j < blockSamples[0].length; j++) {
+        blockSamples[i][j] = new Sample(blockId, i, j, this);
+        samplesByRow.add(blockSamples[i][j].getIdByRow());
+        samplesByColumn.add(blockSamples[i][j].getIdByColumn());
+      }
+    }
   }
 
   /**
@@ -92,7 +112,7 @@ public class Block implements Iterator<Sample>, Cloneable {
    */
   public Object clone() {
     initIterator();
-    Block dolly = new Block(this.blockSamples, this.samples, this.SIZE, this.blockId);
+    Block dolly = new Block(this.blockSamples, this.SIZE, this.blockId);
     return dolly;
   }
 
@@ -112,14 +132,17 @@ public class Block implements Iterator<Sample>, Cloneable {
     return radius;
   }
 
+  /** Returns the block id */
   public long getBlockId() {
     return this.blockId;
   }
 
+  /* Returns all the block samples */
   public Sample[][] getSamples() {
     return this.blockSamples;
   }
 
+  /* Returns the ids of n random selected samples */
   public BigInteger[] getNRandomSamplesIds(int n) {
 
     BigInteger[] samples = new BigInteger[n];
@@ -131,6 +154,7 @@ public class Block implements Iterator<Sample>, Cloneable {
     return samples;
   }
 
+  /* Returns  n random selected samples */
   public Sample[] getNRandomSamples(int n) {
 
     Sample[] samples = new Sample[n];
@@ -142,6 +166,7 @@ public class Block implements Iterator<Sample>, Cloneable {
     return samples;
   }
 
+  /* Returns the ids of n random selected samples */
   public Sample getSample(int row, int column) {
     return this.blockSamples[row][column];
   }
@@ -169,24 +194,64 @@ public class Block implements Iterator<Sample>, Cloneable {
     return s;
   }
 
+  /*Resets the iterator pointers */
   public void initIterator() {
     column = row = 0;
   }
 
+  /* Returns the block matrix size */
   public int getSize() {
     return this.SIZE;
   }
 
+  /* Returns the total number of samples in the block */
   public int getNumSamples() {
     return this.numSamples;
   }
 
+  /* Returns the total number of samples in the block */
   public BigInteger[] getSamplesByRadius(BigInteger peerId, BigInteger radius) {
     BigInteger top = peerId.add(radius);
     BigInteger bottom = peerId.subtract(radius);
 
-    Collection subSet = samples.subSet(bottom, true, top, true);
+    Collection<BigInteger> subSet = samplesByRow.subSet(bottom, true, top, true);
     return (BigInteger[]) subSet.toArray(new BigInteger[0]);
+  }
+
+  /* Returns the ids of the samples within the radius to the peerId specified*/
+  public BigInteger[] getSamplesByRadiusByRow(BigInteger peerId, BigInteger radius) {
+    BigInteger top = peerId.add(radius);
+    BigInteger bottom = peerId.subtract(radius);
+
+    Collection<BigInteger> subSet = samplesByRow.subSet(bottom, true, top, true);
+    return (BigInteger[]) subSet.toArray(new BigInteger[0]);
+  }
+
+  /* Returns the ids of the samples within the radius to the peerId specified, using sample column id*/
+  public BigInteger[] getSamplesByRadiusByColumn(BigInteger peerId, BigInteger radius) {
+    BigInteger top = peerId.add(radius);
+    BigInteger bottom = peerId.subtract(radius);
+
+    Collection<BigInteger> subSet = samplesByColumn.subSet(bottom, true, top, true);
+    return (BigInteger[]) subSet.toArray(new BigInteger[0]);
+  }
+
+  /* Returns the ids of the all the samples in a specific row*/
+  public BigInteger[] getSamplesIdsByRow(int row) {
+    BigInteger[] samples = new BigInteger[this.SIZE];
+    for (int i = 0; i < samples.length; i++) {
+      samples[i] = this.blockSamples[row - 1][i].getIdByRow();
+    }
+    return samples;
+  }
+
+  /* Returns the ids of the all the samples in a specific column*/
+  public BigInteger[] getSamplesIdsByColumn(int column) {
+    BigInteger[] samples = new BigInteger[this.SIZE];
+    for (int i = 0; i < samples.length; i++) {
+      samples[i] = this.blockSamples[i][column - 1].getIdByColumn();
+    }
+    return samples;
   }
 
   private void _init() {

--- a/simulator/src/main/java/peersim/kademlia/das/Sample.java
+++ b/simulator/src/main/java/peersim/kademlia/das/Sample.java
@@ -4,8 +4,6 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class Sample {
 
@@ -13,15 +11,18 @@ public class Sample {
   private int row, column;
   /** The unique ID of the block that this sample belongs to */
   private long blockId;
-  /** The key of a sample in the DHT keyspace (after mapping) */
-  private BigInteger id;
+
+  /** The key of a sample in the DHT keyspace using rows number as reference */
+  private BigInteger idByRow;
+  /** The key of a sample in the DHT keyspace using column number as reference */
+  private BigInteger idByColumn;
   /** Block that this sample is part of */
   private Block block;
 
   /** Initialise a sample instance and map it to the keyspace */
   public Sample(long blockId, int row, int column, Block b) {
 
-    this.id = null;
+    this.idByColumn = this.idByRow = null;
     this.block = b;
     this.row = row;
     this.column = column;
@@ -53,16 +54,23 @@ public class Sample {
             String.valueOf(blockId) + "_" + String.valueOf(row) + "x" + String.valueOf(column);
         MessageDigest digest = MessageDigest.getInstance("SHA-256");
         byte[] hash = digest.digest(idName.getBytes(StandardCharsets.UTF_8));
-        this.id = new BigInteger(1, hash);
+        // this.id = new BigInteger(1, hash);
+        this.idByColumn = new BigInteger(1, hash);
+        this.idByRow = new BigInteger(1, hash);
       } catch (NoSuchAlgorithmException e) {
         e.printStackTrace();
       }
     } else if (KademliaCommonConfigDas.MAPPING_FN
         == KademliaCommonConfigDas.SAMPLE_MAPPING_REGION_BASED) {
-      this.id =
+      this.idByRow =
           Block.INTER_SAMPLE_GAP
               .multiply(BigInteger.valueOf(this.sampleNumberByRow()))
               .add(BigInteger.valueOf(blockId));
+      this.idByColumn =
+          Block.INTER_SAMPLE_GAP
+              .multiply(BigInteger.valueOf(this.sampleNumberByColumn()))
+              .add(BigInteger.valueOf(blockId));
+
     } else {
       System.out.println("Error: invalid selection for sample mapping function");
       System.exit(1);
@@ -72,23 +80,29 @@ public class Sample {
   /** Given the peerID of a node, determine if this sample falls within the region of the node. */
   public boolean isInRegion(BigInteger peerID, BigInteger radius) {
     /** (peerID - radius) < this.id < (peerID + radius) */
-    if ((this.id.compareTo(peerID.subtract(radius)) == 1)
-        && (this.id.compareTo(peerID.add(radius)) == -1)) {
+    return isInRegionByRow(peerID, radius);
+  }
+
+  /** Given the peerID of a node, determine if this sample falls within the region of the node. */
+  public boolean isInRegionByColumn(BigInteger peerID, BigInteger radius) {
+    /** (peerID - radius) < this.id < (peerID + radius) */
+    if ((this.idByColumn.compareTo(peerID.subtract(radius)) == 1)
+        && (this.idByColumn.compareTo(peerID.add(radius)) == -1)) {
       return true;
     } else {
       return false;
     }
   }
 
-  /** Returns the samples ids that are in the region of set of nodes. */
-  public BigInteger[] getNodesInRegion(BigInteger[] nodes, BigInteger radius) {
-
-    List<BigInteger> result = new ArrayList<>();
-    for (BigInteger peerID : nodes)
-      if ((this.id.compareTo(peerID.subtract(radius)) == 1)
-          && (this.id.compareTo(peerID.add(radius)) == -1)) result.add(peerID);
-
-    return (BigInteger[]) result.toArray();
+  /** Given the peerID of a node, determine if this sample falls within the region of the node. */
+  public boolean isInRegionByRow(BigInteger peerID, BigInteger radius) {
+    /** (peerID - radius) < this.id < (peerID + radius) */
+    if ((this.idByRow.compareTo(peerID.subtract(radius)) == 1)
+        && (this.idByRow.compareTo(peerID.add(radius)) == -1)) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   /** Row of the sample */
@@ -108,6 +122,22 @@ public class Sample {
 
   /** Computed identifier of the sample, depending of the mapping mode */
   public BigInteger getId() {
-    return id;
+    return idByRow;
+  }
+
+  /**
+   * Computed identifier of the sample, using rows as reference The id is equal to general id in
+   * case of random mapping
+   */
+  public BigInteger getIdByRow() {
+    return idByRow;
+  }
+
+  /**
+   * Computed identifier of the sample, using columns as reference The id is equal to general id in
+   * case of random mapping
+   */
+  public BigInteger getIdByColumn() {
+    return idByColumn;
   }
 }

--- a/simulator/src/main/java/peersim/kademlia/das/TrafficGeneratorDoubleSample.java
+++ b/simulator/src/main/java/peersim/kademlia/das/TrafficGeneratorDoubleSample.java
@@ -1,0 +1,197 @@
+package peersim.kademlia.das;
+
+import java.math.BigInteger;
+import peersim.config.Configuration;
+import peersim.core.CommonState;
+import peersim.core.Control;
+import peersim.core.Network;
+import peersim.core.Node;
+import peersim.edsim.EDSimulator;
+import peersim.kademlia.KademliaCommonConfig;
+import peersim.kademlia.Message;
+import peersim.kademlia.UniformRandomGenerator;
+
+/**
+ * This control generates samples every 5 min that are stored in a single node (builder) and starts
+ * random sampling from the rest of the nodes In parallel, random lookups are started to start
+ * discovering nodes
+ *
+ * @author Sergi Rene
+ * @version 1.0
+ */
+
+// ______________________________________________________________________________________________
+public class TrafficGeneratorDoubleSample implements Control {
+
+  // ______________________________________________________________________________________________
+  /** MSPastry Protocol to act */
+  private static final String PAR_KADPROT = "kadprotocol";
+
+  private static final String PAR_DASPROT = "dasprotocol";
+
+  /** MSPastry Protocol ID to act */
+  private final int kadpid, daspid;
+
+  /** Mapping function for samples */
+  final String PAR_MAP_FN = "mapping_fn";
+
+  /** Number of sample copies stored per node */
+  final String PAR_NUM_COPIES = "sample_copy_per_node";
+
+  final String PAR_BLK_DIM_SIZE = "block_dim_size";
+
+  int mapfn;
+
+  Block b;
+  private long ID_GENERATOR = 0;
+
+  private boolean first = true, second = true;
+  // ______________________________________________________________________________________________
+  public TrafficGeneratorDoubleSample(String prefix) {
+    kadpid = Configuration.getPid(prefix + "." + PAR_KADPROT);
+    daspid = Configuration.getPid(prefix + "." + PAR_DASPROT);
+
+    KademliaCommonConfigDas.MAPPING_FN = Configuration.getInt(prefix + "." + PAR_MAP_FN);
+    KademliaCommonConfigDas.NUM_SAMPLE_COPIES_PER_PEER =
+        Configuration.getInt(prefix + "." + PAR_NUM_COPIES);
+    KademliaCommonConfigDas.BLOCK_DIM_SIZE =
+        Configuration.getInt(
+            prefix + "." + PAR_BLK_DIM_SIZE, KademliaCommonConfigDas.BLOCK_DIM_SIZE);
+  }
+
+  // ______________________________________________________________________________________________
+  /**
+   * generates a GET message for t1 key.
+   *
+   * @return Message
+   */
+  private Message generateNewBlockMessage(Block b) {
+
+    Message m = Message.makeInitNewBlock(b);
+    m.timestamp = CommonState.getTime();
+
+    return m;
+  }
+
+  // ______________________________________________________________________________________________
+  /**
+   * generates a GET message for t1 key.
+   *
+   * @return Message
+   */
+  private Message generateNewSampleMessage(Sample s) {
+
+    Message m = Message.makeInitGetSample(s.getId());
+    m.timestamp = CommonState.getTime();
+
+    return m;
+  }
+
+  // ______________________________________________________________________________________________
+  /**
+   * generates a random find node message, by selecting randomly the destination.
+   *
+   * @return Message
+   */
+  private Message generateFindNodeMessage() {
+
+    UniformRandomGenerator urg =
+        new UniformRandomGenerator(KademliaCommonConfig.BITS, CommonState.r);
+    BigInteger id = urg.generate();
+
+    Message m = Message.makeInitFindNode(id);
+    m.timestamp = CommonState.getTime();
+
+    return m;
+  }
+
+  // ______________________________________________________________________________________________
+  /**
+   * every call of this control generates and send a random find node message
+   *
+   * @return boolean
+   */
+  public boolean execute() {
+    /*if (first) {
+      for (int i = 0; i < Network.size(); i++) {
+        Node n = Network.get(i);
+        if (n.isUp()) {
+          for (int j = 0; j < 3; j++) {
+            int time = CommonState.r.nextInt(300000);
+            Node start = Network.get(i);
+            Message lookup = generateFindNodeMessage();
+            EDSimulator.add(time, lookup, start, kadpid);
+          }
+        }
+      }
+    } else {
+      for (int i = 0; i < Network.size(); i++) {
+        Node n = Network.get(i);
+        if (n.isUp()) {
+          int time = CommonState.r.nextInt(300000);
+          Node start = Network.get(i);
+          Message lookup = generateFindNodeMessage();
+          EDSimulator.add(time, lookup, start, kadpid);
+        }
+      }*/
+
+    Block b = new Block(KademliaCommonConfigDas.BLOCK_DIM_SIZE, ID_GENERATOR);
+    BigInteger radius = b.computeRegionRadius(KademliaCommonConfigDas.NUM_SAMPLE_COPIES_PER_PEER);
+    int samplesWithinRegion = 0; // samples that are within at least one node's region
+    int totalSamples = 0;
+    while (b.hasNext()) {
+      Sample s = b.next();
+      boolean inRegion = false;
+      // System.out.print("New sample " + s.getColumn() + " " + s.getRow());
+
+      for (int i = 0; i < Network.size(); i++) {
+        Node n = Network.get(i);
+        DASProtocol dasProt = ((DASProtocol) (n.getProtocol(daspid)));
+        // if (dasProt.isBuilder()) EDSimulator.add(0, generateNewBlockMessage(s), n, daspid);
+        // else
+        if (n.isUp()
+            && (s.isInRegionByRow(dasProt.getKademliaId(), radius)
+                || s.isInRegionByColumn(dasProt.getKademliaId(), radius))) {
+          totalSamples++;
+          EDSimulator.add(0, generateNewSampleMessage(s), n, daspid);
+          if (inRegion == false) {
+            samplesWithinRegion++;
+            inRegion = true;
+          }
+        }
+      }
+    }
+
+    for (int i = 0; i < Network.size(); i++) {
+      Node n = Network.get(i);
+      // System.out.println("Block " + b);
+      // Block bis = (Block) b.clone();
+      b.initIterator();
+      EDSimulator.add(0, generateNewBlockMessage(b), n, daspid);
+    }
+
+    System.out.println(
+        ""
+            + samplesWithinRegion
+            + " samples out of "
+            + b.getNumSamples()
+            + " samples are within a node's region");
+
+    System.out.println("" + totalSamples + " total samples distributed");
+    if (samplesWithinRegion != b.getNumSamples()) {
+      System.out.println(
+          "Error: there are "
+              + (b.getNumSamples() - samplesWithinRegion)
+              + " samples that are not within a region of a peer ");
+      // System.exit(1);
+    }
+    // }
+    ID_GENERATOR++;
+    first = false;
+    return false;
+  }
+
+  // ______________________________________________________________________________________________
+
+} // End of class
+// ______________________________________________________________________________________________


### PR DESCRIPTION
Modifications of the sample and block classes to enable double id assignment to nodes using a double assignment, taking into account row order or column order for this sample assignment to nodes ids, in order to have co-located assignment in the hash space, whether from a row perspective or a column perspective.