### PR TITLE
remove operation after max radius increase

### DIFF
--- a/simulator/config/dasprotocol.cfg
+++ b/simulator/config/dasprotocol.cfg
@@ -5,7 +5,7 @@
 # ::::: GLOBAL ::::::
 
 # Network size
-SIZE 5000
+SIZE 1000
 
 # Random seed
 K 5
@@ -72,7 +72,7 @@ protocol.5evildasprotocol.kademlia 3kademlia
 init.1uniqueNodeID peersim.kademlia.das.CustomDistributionDas
 init.1uniqueNodeID.protocolkad 3kademlia
 init.1uniqueNodeID.protocoldas 4dasprotocol
-init.1uniqueNodeID.validator_rate 1.0
+init.1uniqueNodeID.validator_rate 0.5
 init.1uniqueNodeID.protocolEvildas 5evildasprotocol
 
 
@@ -90,7 +90,7 @@ control.0traffic.dasprotocol 4dasprotocol
 control.0traffic.step TRAFFIC_STEP
 control.0traffic.mapping_fn 2
 control.0traffic.sample_copy_per_node 2
-control.0traffic.block_dim_size 512
+control.0traffic.block_dim_size 100
 
 # turbulence non-validator
 control.2turbolenceAdd peersim.kademlia.das.TurbulenceDas

--- a/simulator/src/main/java/peersim/kademlia/das/DASProtocol.java
+++ b/simulator/src/main/java/peersim/kademlia/das/DASProtocol.java
@@ -540,7 +540,9 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
       // also update the time when interface is available again
       long timeNow = CommonState.getTime();
       long latency = propagationLatency;
+      logger.warning("Transmission propagationLatency " + latency);
       latency += (long) transDelay; // truncated value
+      logger.warning("Transmission total latency " + latency);
       if (this.uploadInterfaceBusyUntil > timeNow) {
         latency += this.uploadInterfaceBusyUntil - timeNow;
         this.uploadInterfaceBusyUntil += (long) transDelay; // truncated value

--- a/simulator/src/main/java/peersim/kademlia/das/DASProtocol.java
+++ b/simulator/src/main/java/peersim/kademlia/das/DASProtocol.java
@@ -459,13 +459,16 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
           if (op.getAvailableRequests() == KademliaCommonConfigDas.ALPHA) {
             for (BigInteger sample : op.getSamples()) logger.warning("Missing sample " + sample);
             while (!doSampling(op)) {
-              if (!op.increaseRadius(2)) break;
-              logger.warning("Increasing radius " + op.getId());
+              if (!op.increaseRadius(2)) {
+                logger.warning("Operation completed max increase");
+                samplingOp.remove(m.operationId);
+                logger.warning("Sampling operation finished");
+                KademliaObserver.reportOperation(op);
+                break;
+              }
+              logger.warning(
+                  "Increasing " + op.getRadius() + " " + op.getClass().getCanonicalName());
             }
-            /*samplingOp.remove(m.operationId);
-            logger.warning("Sampling operation finished");
-            KademliaObserver.reportOperation(op);*/
-
           }
         }
       } else {
@@ -727,8 +730,14 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
     op.elaborateResponse(kv.getAll().toArray(new Sample[0]));
     op.setAvailableRequests(KademliaCommonConfigDas.ALPHA);
     while (!doSampling(op)) {
-      if (!op.increaseRadius(2)) break;
-      logger.warning("Increasing radius " + op.getId());
+      if (!op.increaseRadius(2)) {
+        logger.warning("Operation completed max increase");
+        samplingOp.remove(op.getId());
+        logger.warning("Sampling operation finished");
+        KademliaObserver.reportOperation(op);
+        break;
+      }
+      logger.warning("Increasing " + op.getRadius() + " " + op.getClass().getCanonicalName());
     }
   }
 

--- a/simulator/src/main/java/peersim/kademlia/das/TrafficGeneratorSample.java
+++ b/simulator/src/main/java/peersim/kademlia/das/TrafficGeneratorSample.java
@@ -243,6 +243,7 @@ public class TrafficGeneratorSample implements Control {
             }
           }
           if (!inRegion) {
+            System.out.println("Not in region!");
             radius = radius.multiply(BigInteger.valueOf(2));
           }
         }

--- a/simulator/src/main/java/peersim/kademlia/das/operations/SamplingOperation.java
+++ b/simulator/src/main/java/peersim/kademlia/das/operations/SamplingOperation.java
@@ -71,6 +71,10 @@ public abstract class SamplingOperation extends FindOperation {
   }
   // public abstract BigInteger[] startSampling();
 
+  public BigInteger getRadius() {
+    return radius;
+  }
+
   public BigInteger[] doSampling() {
 
     List<BigInteger> nextNodes = new ArrayList<>();
@@ -113,7 +117,7 @@ public abstract class SamplingOperation extends FindOperation {
 
   public boolean increaseRadius(int multiplier) {
     radius = radius.multiply(BigInteger.valueOf(multiplier));
-    if (Block.MAX_KEY.compareTo(radius) < 0) {
+    if (Block.MAX_KEY.compareTo(radius) <= 0) {
       radius = Block.MAX_KEY;
       return false;
     }


### PR DESCRIPTION
small fix that increase radius for a specific operation (multiply per 2) when there are no known nodes in the radius for the requesting samples. Once the max radius is reached (max key in 256 bits space) the operation is finished and removed