### PR TITLE
incorporating bandwidth capacity

### DIFF
--- a/simulator/config/dasprotocol.cfg
+++ b/simulator/config/dasprotocol.cfg
@@ -10,8 +10,8 @@ SIZE 5000
 # Random seed
 K 5
 
-MINDELAY  10
-MAXDELAY  200
+MINDELAY  100
+MAXDELAY  100
 
 #Simulation time in ms
 SIM_TIME 1000*60*9

--- a/simulator/src/main/java/peersim/kademlia/TrafficGenerator.java
+++ b/simulator/src/main/java/peersim/kademlia/TrafficGenerator.java
@@ -52,7 +52,6 @@ public class TrafficGenerator implements Control {
     return m;
   }
 
-
   /**
    * Generates a random region-based find node message, by selecting randomly the destination.
    *
@@ -91,7 +90,7 @@ public class TrafficGenerator implements Control {
 
     // send message
     EDSimulator.add(0, generateFindNodeMessage(), start, pid);
-    //EDSimulator.add(0, generateRegionBasedFindNodeMessage(), start, pid);
+    // EDSimulator.add(0, generateRegionBasedFindNodeMessage(), start, pid);
 
     return false;
   }

--- a/simulator/src/main/java/peersim/kademlia/das/DASProtocol.java
+++ b/simulator/src/main/java/peersim/kademlia/das/DASProtocol.java
@@ -537,9 +537,7 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
       // also update the time when interface is available again
       long timeNow = CommonState.getTime();
       long latency = propagationLatency;
-      logger.warning("Transmission propagationLatency " + latency);
       latency += (long) transDelay; // truncated value
-      logger.warning("Transmission total latency " + latency);
       if (this.uploadInterfaceBusyUntil > timeNow) {
         latency += this.uploadInterfaceBusyUntil - timeNow;
         this.uploadInterfaceBusyUntil += (long) transDelay; // truncated value
@@ -547,8 +545,7 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
       } else {
         this.uploadInterfaceBusyUntil = timeNow + (long) transDelay; // truncated value
       }
-      logger.warning("Transmission busy until " + uploadInterfaceBusyUntil + " " + latency);
-      logger.warning(
+      logger.info(
           "Transmission "
               + latency
               + " "
@@ -566,7 +563,7 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
     if (m.getType() == Message.MSG_GET_SAMPLE) { // is a request
       Timeout t = new Timeout(destId, m.id, m.operationId);
       long latency = transport.getLatency(src, dest);
-      logger.warning("Send message added " + m.id + " " + latency);
+      logger.info("Send message added " + m.id + " " + latency);
 
       // add to sent msg
       this.sentMsg.put(m.id, m.timestamp);

--- a/simulator/src/main/java/peersim/kademlia/das/DASProtocol.java
+++ b/simulator/src/main/java/peersim/kademlia/das/DASProtocol.java
@@ -45,6 +45,9 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
 
   private static String prefix = null;
   private UnreliableTransport transport;
+  /** Store the time until which this node's uplink is busy sending data */
+  private long uploadInterfaceBusyUntil;
+
   private int tid;
   private int kademliaId;
 
@@ -119,6 +122,7 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
     column = new int[KademliaCommonConfigDas.BLOCK_DIM_SIZE + 1];
     samplesRequested = 0;
     queried = new HashSet<BigInteger>();
+    uploadInterfaceBusyUntil = 0;
 
     sentMsg = new TreeMap<Long, Long>();
   }
@@ -506,9 +510,44 @@ public class DASProtocol implements Cloneable, EDProtocol, KademliaEvents, Missi
     Node src = this.kadProtocol.getNode();
     Node dest = this.kadProtocol.nodeIdtoNode(destId);
 
-    transport = (UnreliableTransport) (Network.prototype).getProtocol(tid);
-    transport.send(src, dest, m, myPid);
+    if (m.getType() != Message.MSG_GET_SAMPLE_RESPONSE) {
 
+      transport = (UnreliableTransport) (Network.prototype).getProtocol(tid);
+      transport.send(src, dest, m, myPid);
+    } else {
+      // Send message taking into account the transmission delay and the availability of upload
+      // interface
+      Timeout t = new Timeout(destId, m.id, m.operationId);
+      Sample[] samples = (Sample[]) m.body;
+      BigInteger[] nghbrs = (BigInteger[]) m.value;
+      double msgSize =
+          samples.length * KademliaCommonConfigDas.SAMPLE_SIZE
+              + nghbrs.length * KademliaCommonConfigDas.NODE_RECORD_SIZE;
+      long propagationLatency = transport.getLatency(src, dest);
+      // Add the transmission time of the message (upload)
+      double transDelay = 0.0;
+      if (this.isValidator) {
+        transDelay = 1000 * msgSize / KademliaCommonConfigDas.VALIDATOR_UPLOAD_RATE;
+      } else {
+        transDelay = 1000 * msgSize / KademliaCommonConfigDas.NON_VALIDATOR_UPLOAD_RATE;
+      }
+      // If the interface is busy, incorporate the additional delay
+      // also update the time when interface is available again
+      long timeNow = CommonState.getTime();
+      long latency = propagationLatency;
+      latency += (long) transDelay; // truncated value
+      if (this.uploadInterfaceBusyUntil > timeNow) {
+        latency += this.uploadInterfaceBusyUntil - timeNow;
+        this.uploadInterfaceBusyUntil += (long) transDelay; // truncated value
+      } else {
+        this.uploadInterfaceBusyUntil = timeNow + (long) transDelay; // truncated value
+      }
+      // add to sent msg
+      this.sentMsg.put(m.id, m.timestamp);
+      EDSimulator.add(latency, m, dest, myPid);
+    }
+
+    // Setup timeout
     if (m.getType() == Message.MSG_GET_SAMPLE) { // is a request
       Timeout t = new Timeout(destId, m.id, m.operationId);
       long latency = transport.getLatency(src, dest);

--- a/simulator/src/main/java/peersim/kademlia/das/KademliaCommonConfigDas.java
+++ b/simulator/src/main/java/peersim/kademlia/das/KademliaCommonConfigDas.java
@@ -47,4 +47,6 @@ public class KademliaCommonConfigDas {
 
   /** Default upload bandwith of a non-validator in Mbits/sec */
   public static int NON_VALIDATOR_UPLOAD_RATE = 20;
+
+  public static int BUILDER_UPLOAD_RATE = 10000;
 }

--- a/simulator/src/main/java/peersim/kademlia/das/KademliaCommonConfigDas.java
+++ b/simulator/src/main/java/peersim/kademlia/das/KademliaCommonConfigDas.java
@@ -25,6 +25,15 @@ public class KademliaCommonConfigDas {
   /** Number of samples retrieved for the random sampling */
   public static int N_SAMPLES = 75;
 
+  /**
+   * Size of a node record (a single neighbor information returned alongside samples in
+   * GET_SAMPLE_RESPONSE) in Mbits - I used ENR size for this, which is 300 bytes
+   */
+  public static double NODE_RECORD_SIZE = 0.0024;
+
+  /** Size of a sample in Mbits - each cell contains 512 B of data + 48 B KZG commitment */
+  public static double SAMPLE_SIZE = 0.00448;
+
   /** Number of samples returned by a single node */
   public static int MAX_SAMPLES_RETURNED = 1000;
 
@@ -32,4 +41,10 @@ public class KademliaCommonConfigDas {
 
   /** Number of samples returned by a single node */
   public static int MAX_HOPS = 5000;
+
+  /** Default upload bandwith of a validator in Mbits/sec */
+  public static int VALIDATOR_UPLOAD_RATE = 100;
+
+  /** Default upload bandwith of a non-validator in Mbits/sec */
+  public static int NON_VALIDATOR_UPLOAD_RATE = 20;
 }


### PR DESCRIPTION
+ Added transmission delay to the message latency computation
+ Defined  separate upload bandwidth capacities for validator and non-validator nodes
+ Added logic to keep track of when an upstream interface is busy sending data and incorporated the busy periods when computing the latency of sending data 